### PR TITLE
B1792 redis timeout

### DIFF
--- a/redis/listener.go
+++ b/redis/listener.go
@@ -48,6 +48,10 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
+			} else if errors.Is(err, redis.Nil) {
+				// we get this error when no results are returned
+				// not exactly sure why but we want to continue listening
+				continue
 			} else {
 				return err
 			}

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/go-redis/redis/v8"
 	"github.com/nullstone-io/go-streaming/stream"
-	"log"
 	"time"
 )
 
@@ -34,7 +33,6 @@ func NewListener(redisClient *redis.Client, streamName string, adapter Adapter) 
 func (r *Listener) Listen(ctx context.Context, cursor string) error {
 	if cursor == "-1" {
 		cursor = fmt.Sprintf("%d", time.Now().UnixMilli())
-		log.Printf("Setting cursor to %s\n", cursor)
 	}
 
 	for {
@@ -42,11 +40,7 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 			Streams: []string{r.streamName, cursor},
 			Block:   100 * time.Millisecond,
 		}
-		// log.Printf("Reading from stream %s with cursor %s\n", r.streamName, cursor)
 		groups, err := r.redisClient.XRead(ctx, &args).Result()
-		// log.Printf("groups: %+v\n", groups)
-		// log.Printf("err: %+v\n", err)
-		// log.Printf("%T\n", err)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
@@ -76,7 +70,6 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		// we do this instead of making the XRead call block so we don't hold open a connection to redis
 		case <-time.After(dur):
 		case <-ctx.Done():
-			// log.Printf("context cancelled\n")
 			return nil
 		}
 	}

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -38,7 +38,6 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 	for {
 		args := redis.XReadArgs{
 			Streams: []string{r.streamName, cursor},
-			Block:   100 * time.Millisecond,
 		}
 		log.Printf("Reading from stream %s with cursor %s\n", r.streamName, cursor)
 		groups, err := r.redisClient.XRead(ctx, &args).Result()

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -14,7 +14,7 @@ type Adapter interface {
 	Flush()
 }
 
-const dur = 1 * time.Second
+const waitDuration = 1 * time.Second
 
 type Listener struct {
 	streamName  string
@@ -68,7 +68,7 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		select {
 		// wait for a set period between each query to redis to not overload it
 		// we do this instead of making the XRead call block so we don't hold open a connection to redis
-		case <-time.After(dur):
+		case <-time.After(waitDuration):
 		case <-ctx.Done():
 			return nil
 		}

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -3,8 +3,10 @@ package redis
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/go-redis/redis/v8"
 	"github.com/nullstone-io/go-streaming/stream"
+	"log"
 	"time"
 )
 
@@ -31,7 +33,8 @@ func NewListener(redisClient *redis.Client, streamName string, adapter Adapter) 
 
 func (r *Listener) Listen(ctx context.Context, cursor string) error {
 	if cursor == "-1" {
-		cursor = "$" // the special id $ allows us to start streaming from this point in time, even if the stream doesn't exist yet
+		cursor = fmt.Sprintf("%d", time.Now().UnixMilli())
+		log.Printf("Setting cursor to %s\n", cursor)
 	}
 
 	for {
@@ -50,21 +53,26 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 			} else if !errors.Is(err, redis.Nil) {
 				// when no results are found, this lib returns a redis.Nil error
 				// not exactly sure why but we want to continue listening
+				// only return an error here if it's not a redis.Nil error
 				return err
 			}
-		}
-		for _, grp := range groups {
-			for _, msg := range grp.Messages {
-				m := stream.Message{
-					Context: msg.Values["context"].(string),
-					Content: msg.Values["content"].(string),
+		} else {
+			for _, grp := range groups {
+				for _, msg := range grp.Messages {
+					m := stream.Message{
+						Context: msg.Values["context"].(string),
+						Content: msg.Values["content"].(string),
+					}
+					r.adapter.Send(m)
+					cursor = msg.ID
 				}
-				r.adapter.Send(m)
-				cursor = msg.ID
 			}
+			// if we got results back, we don't want to wait for the timeout below
+			// instead, loop back and query redis again immediately
+			continue
 		}
 		select {
-		// wait for 1 second between each query to redis
+		// wait for a set period between each query to redis to not overload it
 		// we do this instead of making the XRead call block so we don't hold open a connection to redis
 		case <-time.After(dur):
 		case <-ctx.Done():

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -43,6 +43,7 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		groups, err := r.redisClient.XRead(ctx, &args).Result()
 		log.Printf("groups: %+v\n", groups)
 		log.Printf("err: %+v\n", err)
+		log.Printf("%T\n", err)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/go-redis/redis/v8"
 	"github.com/nullstone-io/go-streaming/stream"
+	"log"
 	"time"
 )
 
@@ -38,6 +39,7 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		args := redis.XReadArgs{
 			Streams: []string{r.streamName, cursor},
 		}
+		log.Printf("Reading from stream %s with cursor %s\n", r.streamName, cursor)
 		groups, err := r.redisClient.XRead(ctx, &args).Result()
 		if err != nil {
 			if errors.Is(err, context.Canceled) {

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -38,6 +38,7 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 	for {
 		args := redis.XReadArgs{
 			Streams: []string{r.streamName, cursor},
+			Block:   100 * time.Millisecond,
 		}
 		log.Printf("Reading from stream %s with cursor %s\n", r.streamName, cursor)
 		groups, err := r.redisClient.XRead(ctx, &args).Result()

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -48,11 +48,9 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
-			} else if errors.Is(err, redis.Nil) {
-				// we get this error when no results are returned
+			} else if !errors.Is(err, redis.Nil) {
+				// when no results are found, this lib returns a redis.Nil error
 				// not exactly sure why but we want to continue listening
-				continue
-			} else {
 				return err
 			}
 		}

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -15,7 +15,7 @@ type Adapter interface {
 	Flush()
 }
 
-const dur = 3 * time.Second
+const dur = 1 * time.Second
 
 type Listener struct {
 	streamName  string

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -68,6 +68,9 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		// wait for 1 second between each query to redis
 		// we do this instead of making the XRead call block so we don't hold open a connection to redis
 		case <-time.After(dur):
+		case <-ctx.Done():
+			log.Printf("context cancelled\n")
+			return nil
 		}
 	}
 }

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -42,6 +42,8 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		}
 		log.Printf("Reading from stream %s with cursor %s\n", r.streamName, cursor)
 		groups, err := r.redisClient.XRead(ctx, &args).Result()
+		log.Printf("groups: %+v\n", groups)
+		log.Printf("err: %+v\n", err)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"github.com/go-redis/redis/v8"
 	"github.com/nullstone-io/go-streaming/stream"
-	"log"
 	"time"
 )
 
@@ -14,7 +13,7 @@ type Adapter interface {
 	Flush()
 }
 
-const dur = 1 * time.Second
+const dur = 3 * time.Second
 
 type Listener struct {
 	streamName  string
@@ -40,11 +39,11 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 			Streams: []string{r.streamName, cursor},
 			Block:   100 * time.Millisecond,
 		}
-		log.Printf("Reading from stream %s with cursor %s\n", r.streamName, cursor)
+		// log.Printf("Reading from stream %s with cursor %s\n", r.streamName, cursor)
 		groups, err := r.redisClient.XRead(ctx, &args).Result()
-		log.Printf("groups: %+v\n", groups)
-		log.Printf("err: %+v\n", err)
-		log.Printf("%T\n", err)
+		// log.Printf("groups: %+v\n", groups)
+		// log.Printf("err: %+v\n", err)
+		// log.Printf("%T\n", err)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
@@ -69,7 +68,7 @@ func (r *Listener) Listen(ctx context.Context, cursor string) error {
 		// we do this instead of making the XRead call block so we don't hold open a connection to redis
 		case <-time.After(dur):
 		case <-ctx.Done():
-			log.Printf("context cancelled\n")
+			// log.Printf("context cancelled\n")
 			return nil
 		}
 	}


### PR DESCRIPTION
This PR updates the streaming from redis to use a non-blocking strategy. The theory is that the blocking strategy caused connection timeouts because they held onto connections and we didn't have enough for new requests.

Instead of blocking and waiting, we put the streaming into a loop that queries redis every 1 second.
Because of this we can't use the $ special character, but instead need to calculate the start time in milliseconds.

If a request comes back with data, we want to immediately query again.