### PR TITLE
Panic closed channel

### DIFF
--- a/listener/channel_adapter.go
+++ b/listener/channel_adapter.go
@@ -2,22 +2,44 @@ package listener
 
 import (
 	"github.com/nullstone-io/go-streaming/stream"
+	"sync"
 )
 
 type ChannelAdapter struct {
-	messages chan<- stream.Message
+	messages chan stream.Message
+	mu       sync.Mutex
+	closed   bool
 }
 
-func NewChannelAdapter(messages chan<- stream.Message) *ChannelAdapter {
+func NewChannelAdapter() *ChannelAdapter {
 	return &ChannelAdapter{
-		messages: messages,
+		messages: make(chan stream.Message),
 	}
 }
 
-func (c *ChannelAdapter) Send(message stream.Message) {
-	c.messages <- message
+func (a *ChannelAdapter) Channel() <-chan stream.Message {
+	return a.messages
 }
 
-func (c *ChannelAdapter) Flush() {
+func (a *ChannelAdapter) Send(message stream.Message) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return
+	}
+
+	a.messages <- message
+}
+
+func (a *ChannelAdapter) Flush() {
 	// Do nothing
+}
+
+func (a *ChannelAdapter) Close() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.closed {
+		close(a.messages)
+	}
+	a.closed = true
 }

--- a/listener/log_adapter_test.go
+++ b/listener/log_adapter_test.go
@@ -100,22 +100,19 @@ func TestBufferedChannelAdapter(t *testing.T) {
 			defer cancel()
 
 			gotMsgs := make([]stream.Message, 0)
-			messages := make(chan stream.Message)
+			adapter := NewBufferedChannelAdapter()
 
 			go func() {
-				defer close(messages)
-				adapter := NewBufferedChannelAdapter(messages)
 				defer adapter.Close()
 				for _, msg := range test.msgs {
 					adapter.Send(msg)
 				}
-				adapter.Flush()
 			}()
 
 			func() {
 				for {
 					select {
-					case message, ok := <-messages:
+					case message, ok := <-adapter.Channel():
 						if !ok {
 							return
 						}

--- a/redis/listener.go
+++ b/redis/listener.go
@@ -12,6 +12,7 @@ import (
 type Adapter interface {
 	Send(message stream.Message)
 	Flush()
+	Close()
 }
 
 const waitDuration = 1 * time.Second


### PR DESCRIPTION
This fixes a panic I recently received when using the `listener.ChannelAdapter`:
```
 panic: send on closed channel
 
 goroutine 5059 [running]:
 github.com/nullstone-io/go-streaming/listener.(*ChannelAdapter).Send(0xc00007e380?, {{0x0, 0x0}, {0xc000ee3560, 0x7}, {0xc000870000, 0x6f}, 0x0})
        /go/pkg/mod/github.com/nullstone-io/go-streaming@v0.0.0-20240307200854-e7d952d02b07/listener/channel_adapter.go:18 +0x3e
 github.com/nullstone-io/nullfire/api.(*WorkspaceWorkflowsStreamAdapter).Send(0xc00093a000, {{0x0, 0x0}, {0xc000ee3560, 0x7}, {0xc000870000, 0x6f}, 0x0})
        /src/api/workspace_workflows.go:302 +0x1a6
 github.com/nullstone-io/go-streaming/redis.(*Listener).Listen(0xc001380150, {0x1b60520, 0xc001422690}, {0x18c4ed6?, 0x6b8000006f5?})
        /go/pkg/mod/github.com/nullstone-io/go-streaming@v0.0.0-20240307200854-e7d952d02b07/redis/listener.go:60 +0x46f
```

This follows go advice to make the func/struct that sends on a channel be the full owner. (i.e. creates the channel, sends on the channel, and closes the channel)