### PR TITLE
Fix adapter teardown deadlock that leaked websocket goroutines (NUL-131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,95 @@
 # go-streaming
+
+Building blocks for streaming real-time data from Nullstone services to browsers. A producer publishes messages (logs, object change events) onto a Redis Stream; an API endpoint tails that stream and relays each message over a websocket to the client.
+
+```
+ producer service                      consumer endpoint (e.g. nullfire, enigma)
+┌──────────────────┐      ┌──────────────────────────────────────────────────┐
+│ stream.Publisher │      │ redis.Listener → Adapter (chan) → websocket.Broker│
+│  (redis XADD)    │─────▶│        (XREAD poll)                    (gorilla) │
+└──────────────────┘      └──────────────────────────────────────────────────┘
+        Redis Stream (expires 1h after last activity)          │
+                                                               ▼
+                                                            browser
+```
+
+## Packages
+
+### `stream`
+
+The shared vocabulary. `Message` is the unit that flows through every layer:
+
+```go
+type Message struct {
+    Type    string         `json:"type"`
+    Context string         `json:"context"`           // phase name or event type ("created", "updated", "hydrate", "eot", ...)
+    Content string         `json:"content"`           // log text or a JSON-serialized object
+    Details map[string]any `json:"details,omitempty"`
+}
+```
+
+- `Publisher` is the producer-side interface (`PublishLogs`, `PublishObject`, `PublishEot`), with `ContextWithPublisher`/`PublisherFromContext` helpers for threading it through request contexts.
+- `EndOfTransmission` (`\x04`) is the sentinel appended to `Content` to signal that a stream is complete; consumers use it to close the websocket cleanly.
+- `MockPublisher` is a testify mock of `Publisher` for tests.
+
+### `redis`
+
+Redis Streams transport.
+
+- `NewClient` builds a `go-redis` client from a URL, with optional pool sizing and OpenTelemetry instrumentation.
+- `Publisher` implements `stream.Publisher` via `XADD`. Log messages use the log id as the entry ID so replays are ordered; every publish refreshes a 1-hour TTL on the stream, so streams evaporate an hour after the last activity.
+- `Listener` tails a stream with `XREAD` (100ms block, 1s wait between polls so connections aren't held open) and forwards each entry to an `Adapter`. A cursor of `"-1"` means "start from now". It exits cleanly on context cancellation.
+
+### `listener`
+
+Adapters that bridge a `redis.Listener` to a consumer channel.
+
+- `ChannelAdapter` — unbuffered pass-through; every message is delivered individually.
+- `BufferedChannelAdapter` — coalesces log content and flushes when the buffer exceeds 1KB, when the message's `Context` (workflow phase) changes, or after a 1s tick. Use it for high-volume log streams so the websocket isn't flooded with tiny frames.
+
+Both adapters are safe to `Close()` at any time, including while a producer is blocked mid-`Send` because the consumer stopped reading (e.g. the websocket client disconnected) — `Close()` releases the blocked sender instead of deadlocking, and `Send` after `Close` is a no-op. `BufferedChannelAdapter.Close()` makes a best-effort (1s-bounded) delivery of any remaining buffered content to a live consumer.
+
+### `websocket`
+
+`Broker` upgrades an HTTP request (gorilla/websocket) and pumps messages from an adapter's channel to the client:
+
+- Messages are sent as JSON. A `Content` ending in `stream.EndOfTransmission` is trimmed and followed by a normal close frame.
+- Errors received on the errors channel are sent as a `{"context": "error"}` message followed by a close frame (error text can exceed the 125-byte close-frame payload limit, so it travels as a message first).
+- Replies to `ping` text messages with an echo, matching the heartbeat that `@vueuse/core`'s `useWebSocket` sends from the browser.
+- `WaitForClose()` blocks until the client disconnects; writes are mutex-guarded so the write loop and pong replies don't interleave frames.
+
+### `file`
+
+`Listener` tails a local file (creating it if needed) and copies new lines to an `io.Writer` every 100ms until `Finish()` is called, reading any remainder before returning. Used to relay logs written to disk by external processes.
+
+## Typical endpoint wiring
+
+```go
+msgs := listener.NewChannelAdapter()
+defer msgs.Close()
+
+broker, err := websocket.StartBroker(w, r, msgs.Channel(), errsCh)
+if err != nil {
+    return
+}
+
+// hydrate: send current state as the first message
+msgs.Send(stream.Message{Context: "hydrate", Content: initialJSON})
+
+// tail the redis stream until the client disconnects
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+go redis.NewListener(redisClient, streamName, msgs).Listen(ctx, "-1")
+
+broker.WaitForClose()
+```
+
+Order teardown so the context is cancelled before the adapter closes (deferred calls run in reverse): the stream listener stops producing, then the adapter releases anything still blocked.
+
+## Development
+
+```sh
+make test   # go fmt + go test -v ./...
+```
+
+No Redis instance is required for the test suite. This module is consumed by `nullfire` and `enigma`; after merging changes here, bump `github.com/nullstone-io/go-streaming` in their `go.mod` and re-vendor.

--- a/listener/buffered_channel_adapter.go
+++ b/listener/buffered_channel_adapter.go
@@ -17,6 +17,8 @@ type BufferedChannelAdapter struct {
 	buffer       *bytes.Buffer
 	currentPhase string
 	ticker       *time.Ticker
+	done         chan struct{}
+	closeOnce    sync.Once
 	mu           sync.Mutex
 	closed       bool
 }
@@ -26,6 +28,7 @@ func NewBufferedChannelAdapter() *BufferedChannelAdapter {
 		messages: make(chan stream.Message),
 		buffer:   bytes.NewBufferString(""),
 		ticker:   time.NewTicker(bufferTimeout),
+		done:     make(chan struct{}),
 	}
 
 	go adapter.flushOnTick()
@@ -38,11 +41,16 @@ func (a *BufferedChannelAdapter) Channel() <-chan stream.Message {
 }
 
 func (a *BufferedChannelAdapter) Send(message stream.Message) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return
+	}
+
 	// First check to see if this message belongs to a different workflow phase
 	// If it does, flush all previous messages
-
 	if a.currentPhase != "" && a.currentPhase != message.Context {
-		a.Flush()
+		a.flushLocked(false)
 	}
 	a.currentPhase = message.Context
 
@@ -50,7 +58,7 @@ func (a *BufferedChannelAdapter) Send(message stream.Message) {
 
 	// If we have exceeded the min buffer length, flush the content to the stream
 	if a.buffer.Len() > maxBufferLength {
-		a.Flush()
+		a.flushLocked(false)
 	}
 }
 
@@ -60,7 +68,17 @@ func (a *BufferedChannelAdapter) Flush() {
 	if a.closed {
 		return
 	}
+	a.flushLocked(false)
+}
 
+// flushLocked emits the buffered content to the channel; the caller must hold mu.
+// If the consumer has stopped reading (e.g. the websocket client disconnected),
+// an unguarded channel send would block forever while holding the mutex,
+// deadlocking Close(). done unblocks the send so Close() can proceed.
+// The final flush during Close() runs with done already closed, so it uses a
+// bounded timer instead: a live consumer still receives the tail, a dead one
+// only delays Close() by the timeout.
+func (a *BufferedChannelAdapter) flushLocked(closing bool) {
 	a.ticker.Reset(bufferTimeout)
 
 	// Do not send a message if there is no buffered content
@@ -76,20 +94,41 @@ func (a *BufferedChannelAdapter) Flush() {
 	}
 	a.buffer.Reset()
 
-	a.messages <- m
+	if closing {
+		t := time.NewTimer(bufferTimeout)
+		defer t.Stop()
+		select {
+		case a.messages <- m:
+		case <-t.C:
+		}
+		return
+	}
+	select {
+	case a.messages <- m:
+	case <-a.done:
+	}
 }
 
 func (a *BufferedChannelAdapter) flushOnTick() {
-	for range a.ticker.C {
-		a.Flush()
+	for {
+		select {
+		case <-a.ticker.C:
+			a.Flush()
+		case <-a.done:
+			return
+		}
 	}
 }
 
 func (a *BufferedChannelAdapter) Close() {
-	a.Flush()
+	// Signal done before acquiring the mutex; a Send/Flush blocked on the channel
+	// holds the mutex and needs done to release it. This also stops flushOnTick.
+	a.closeOnce.Do(func() { close(a.done) })
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if !a.closed {
+		// Best-effort delivery of any remaining buffered content
+		a.flushLocked(true)
 		close(a.messages)
 		a.ticker.Stop()
 	}

--- a/listener/channel_adapter.go
+++ b/listener/channel_adapter.go
@@ -6,14 +6,17 @@ import (
 )
 
 type ChannelAdapter struct {
-	messages chan stream.Message
-	mu       sync.Mutex
-	closed   bool
+	messages  chan stream.Message
+	done      chan struct{}
+	closeOnce sync.Once
+	mu        sync.Mutex
+	closed    bool
 }
 
 func NewChannelAdapter() *ChannelAdapter {
 	return &ChannelAdapter{
 		messages: make(chan stream.Message),
+		done:     make(chan struct{}),
 	}
 }
 
@@ -28,7 +31,13 @@ func (a *ChannelAdapter) Send(message stream.Message) {
 		return
 	}
 
-	a.messages <- message
+	// If the consumer has stopped reading (e.g. the websocket client disconnected),
+	// an unguarded channel send would block forever while holding the mutex,
+	// deadlocking Close(). done unblocks the send so Close() can proceed.
+	select {
+	case a.messages <- message:
+	case <-a.done:
+	}
 }
 
 func (a *ChannelAdapter) Flush() {
@@ -36,6 +45,9 @@ func (a *ChannelAdapter) Flush() {
 }
 
 func (a *ChannelAdapter) Close() {
+	// Signal done before acquiring the mutex; a Send blocked on the channel
+	// holds the mutex and needs done to release it
+	a.closeOnce.Do(func() { close(a.done) })
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if !a.closed {

--- a/listener/channel_adapter_test.go
+++ b/listener/channel_adapter_test.go
@@ -1,0 +1,150 @@
+package listener
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nullstone-io/go-streaming/stream"
+	"github.com/stretchr/testify/assert"
+)
+
+// runWithTimeout fails the test if fn does not return within the timeout.
+// This guards the deadlock regression tests below from hanging the suite.
+func runWithTimeout(t *testing.T, timeout time.Duration, name string, fn func()) {
+	t.Helper()
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		fn()
+	}()
+	select {
+	case <-finished:
+	case <-time.After(timeout):
+		t.Fatalf("%s did not return within %s (deadlock)", name, timeout)
+	}
+}
+
+func TestChannelAdapter_CloseUnblocksSendWithNoConsumer(t *testing.T) {
+	adapter := NewChannelAdapter()
+
+	// Simulate the websocket broker's writeLoop exiting (client disconnected):
+	// nobody reads from adapter.Channel(), so Send blocks on the unbuffered channel
+	sendReturned := make(chan struct{})
+	go func() {
+		defer close(sendReturned)
+		adapter.Send(stream.Message{Context: "updated", Content: "orphaned"})
+	}()
+
+	// Give Send time to park on the channel send while holding the mutex
+	time.Sleep(50 * time.Millisecond)
+
+	runWithTimeout(t, 2*time.Second, "Close", adapter.Close)
+
+	select {
+	case <-sendReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not return after Close (leaked goroutine)")
+	}
+}
+
+func TestChannelAdapter_SendAfterCloseIsNoop(t *testing.T) {
+	adapter := NewChannelAdapter()
+	adapter.Close()
+	runWithTimeout(t, 2*time.Second, "Send", func() {
+		adapter.Send(stream.Message{Context: "updated", Content: "after close"})
+	})
+}
+
+func TestChannelAdapter_CloseIsIdempotent(t *testing.T) {
+	adapter := NewChannelAdapter()
+	adapter.Close()
+	runWithTimeout(t, 2*time.Second, "second Close", adapter.Close)
+}
+
+func TestChannelAdapter_DeliversToConsumer(t *testing.T) {
+	adapter := NewChannelAdapter()
+	defer adapter.Close()
+
+	received := make(chan stream.Message, 1)
+	go func() {
+		received <- <-adapter.Channel()
+	}()
+
+	adapter.Send(stream.Message{Context: "updated", Content: "hello"})
+
+	select {
+	case m := <-received:
+		assert.Equal(t, "updated", m.Context)
+		assert.Equal(t, "hello", m.Content)
+	case <-time.After(2 * time.Second):
+		t.Fatal("message was not delivered to consumer")
+	}
+}
+
+func TestBufferedChannelAdapter_CloseUnblocksSendWithNoConsumer(t *testing.T) {
+	adapter := NewBufferedChannelAdapter()
+
+	// Exceed maxBufferLength so Send flushes and parks on the channel send
+	// with no consumer reading
+	sendReturned := make(chan struct{})
+	go func() {
+		defer close(sendReturned)
+		adapter.Send(stream.Message{Context: "phase1", Content: strings.Repeat("x", maxBufferLength+1)})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	runWithTimeout(t, 2*time.Second, "Close", adapter.Close)
+
+	select {
+	case <-sendReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not return after Close (leaked goroutine)")
+	}
+}
+
+func TestBufferedChannelAdapter_CloseDeliversTailToLiveConsumer(t *testing.T) {
+	adapter := NewBufferedChannelAdapter()
+
+	received := make(chan stream.Message, 1)
+	go func() {
+		for m := range adapter.Channel() {
+			received <- m
+		}
+	}()
+
+	adapter.Send(stream.Message{Context: "phase1", Content: "tail content"})
+	adapter.Close()
+
+	select {
+	case m := <-received:
+		assert.Equal(t, "phase1", m.Context)
+		assert.Equal(t, "tail content", m.Content)
+	case <-time.After(2 * time.Second):
+		t.Fatal("buffered tail content was not delivered on Close")
+	}
+}
+
+func TestBufferedChannelAdapter_FlushesOnPhaseChange(t *testing.T) {
+	adapter := NewBufferedChannelAdapter()
+	defer adapter.Close()
+
+	received := make(chan stream.Message, 2)
+	go func() {
+		for m := range adapter.Channel() {
+			received <- m
+		}
+	}()
+
+	adapter.Send(stream.Message{Context: "phase1", Content: "first"})
+	adapter.Send(stream.Message{Context: "phase2", Content: "second"})
+
+	select {
+	case m := <-received:
+		assert.Equal(t, "phase1", m.Context)
+		assert.Equal(t, "first", m.Content)
+	case <-time.After(2 * time.Second):
+		t.Fatal("phase1 content was not flushed on phase change")
+	}
+}


### PR DESCRIPTION
ChannelAdapter.Send and BufferedChannelAdapter flushes blocked forever on their unbuffered channel while holding the mutex once the consumer (the websocket broker writeLoop) exited on client disconnect. Close() then deadlocked on that mutex, permanently leaking the endpoint handler goroutine, the stream listener goroutine, and the connection.

Both adapters now carry a done channel closed by Close() before it takes the mutex, so a parked send is released and Close() completes. The buffered adapter's final flush uses a bounded timer instead so a live consumer still receives the tail. Also fixes the unsynchronized buffer access between Send and the ticker goroutine, and the flushOnTick goroutine leaking after Close (ticker.Stop does not close ticker.C).